### PR TITLE
Add RcppThread::Rcerr

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Provides R-friendly threading functionality: 
 
   * thread safe versions of [Rcpp's](http://www.rcpp.org/)
-    `checkUserInterrupt()` and `Rcout`,
+    `checkUserInterrupt()`, `Rcout`, and `Rcerr`,
   * an interruptible thread class that otherwise behaves like 
    [`std::thread`](http://en.cppreference.com/w/cpp/thread/thread),
   * classes for the [thread pool
@@ -28,6 +28,8 @@ For a detailed description of its functionality and examples, see the associated
 or the [API documentation](https://tnagler.github.io/RcppThread/).
 
 Since then, the following **new features** have been added:
+
+- Printing to the error stream with `Rcerr`.
 
 - Free-standing functions like `parallelFor()` now dispatch 
   to a global thread pool that persists for the entire session. This 
@@ -99,13 +101,14 @@ before including any headers in your source code.
 1. Add the line `CXX_STD = CXX11` to the `src/Makevars(.win)` files of your package.
 2. Add `RcppThread` to the `LinkingTo` field of your `DESCRIPTION` file.
 
-## Automatic override of `std::cout` and `std::thread`
+## Automatic override of `std::cout`, `std::cerr``, and `std::thread`
 
-There are preprocessor options to replace all occurrences of `std::cout` and 
-`std::thread` with calls to `RcppThread::Rcout` and `RcppThread::Thread` 
+There are preprocessor options to replace all occurrences of `std::cout`, `std::cerr`, and `std::thread` with calls to `RcppThread::Rcout`, `RcppThread::Rcerr`, and `RcppThread::Thread`
 (provided that the RcppThread headers are included first). To enable this, use 
+
 ```
 #define RCPPTHREAD_OVERRIDE_COUT 1    // std::cout override
+#define RCPPTHREAD_OVERRIDE_CERR 1    // std::cerr override
 #define RCPPTHREAD_OVERRIDE_THREAD 1  // std::thread override
 ```
 before including the RcppThread headers.

--- a/inst/include/RcppThread.h
+++ b/inst/include/RcppThread.h
@@ -8,6 +8,7 @@
 
 #include "RcppThread/RMonitor.hpp"
 #include "RcppThread/Rcout.hpp"
+#include "RcppThread/Rcerr.hpp"
 #include "RcppThread/Thread.hpp"
 #include "RcppThread/ThreadPool.hpp"
 #include "RcppThread/parallelFor.hpp"

--- a/inst/include/RcppThread/Rcerr.hpp
+++ b/inst/include/RcppThread/Rcerr.hpp
@@ -1,0 +1,66 @@
+// Copyright © 2021 Thomas Nagler
+//
+// This file is part of the RcppThread and licensed under the terms of
+// the MIT license. For a copy, see the LICENSE.md file in the root directory of
+// RcppThread or https://github.com/tnagler/RcppThread/blob/master/LICENSE.md.
+
+#pragma once
+
+#include <ostream>
+#include "RcppThread/RMonitor.hpp"
+
+namespace RcppThread {
+
+//! Safely printing to the R console from threaded code.
+class RErrPrinter {
+public:
+
+    //! prints `object` to R error stream íf called from main thread; otherwise
+    //! adds a printable version of `object` to a buffer for deferred printing.
+    //! @param object a string (or coercible object) to print.
+    //! @details Declared as a friend in `RMonitor`.
+    template<class T>
+    RErrPrinter& operator<< (T& object)
+    {
+        RMonitor::instance().safelyPrintErr(object);
+        return *this;
+    }
+
+    //! prints `object` to R error stream íf called from main thread; otherwise
+    //! adds a printable version of `object` to a buffer for deferred printing.
+    //! @param object a string (or coercible object) to print.
+    //! @details Declared as a friend in `RMonitor`.
+    template<class T>
+    RErrPrinter& operator<< (const T& object)
+    {
+        RMonitor::instance().safelyPrintErr(object);
+        return *this;
+    }
+
+    //! prints `object` to R error stream íf called from main thread; otherwise
+    //! adds a printable version of `object` to a buffer for deferred printing.
+    //! @param object a string (or coercible object) to print.
+    //! @details Declared as a friend in `RMonitor`.
+    RErrPrinter& operator<< (std::ostream& (*object)(std::ostream&))
+    {
+        RMonitor::instance().safelyPrintErr(object);
+        return *this;
+    }
+};
+
+//! global `RPrinter` instance called 'Rcerr' (as in Rcpp).
+static RErrPrinter Rcerr = RErrPrinter();
+
+}
+
+// override std::cout to use RcppThread::Rcout instead
+#ifndef RCPPTHREAD_OVERRIDE_CERR
+    #define RCPPTHREAD_OVERRIDE_CERR 0
+#endif
+
+#if RCPPTHREAD_OVERRIDE_CERR
+    #define cerr RcppThreadRcerr
+    namespace std {
+        static RcppThread::RErrPrinter RcppThreadRcerr = RcppThread::RErrPrinter();
+    }
+#endif

--- a/inst/include/RcppThread/Thread.hpp
+++ b/inst/include/RcppThread/Thread.hpp
@@ -8,6 +8,7 @@
 
 #include "RcppThread/RMonitor.hpp"
 #include "RcppThread/Rcout.hpp"
+#include "RcppThread/Rcerr.hpp"
 
 #include <thread>
 #include <future>
@@ -81,6 +82,7 @@ public:
         auto timeout = std::chrono::milliseconds(250);
         while (future_.wait_for(timeout) != std::future_status::ready) {
             Rcout << "";
+            Rcerr << "";
             if (isInterrupted())
                 break;
             std::this_thread::yield();
@@ -88,6 +90,7 @@ public:
         if (thread_.joinable())
             thread_.join();
         Rcout << "";
+        Rcerr << "";
         checkUserInterrupt();
     }
 

--- a/inst/include/RcppThread/ThreadPool.hpp
+++ b/inst/include/RcppThread/ThreadPool.hpp
@@ -8,6 +8,7 @@
 
 #include "RcppThread/RMonitor.hpp"
 #include "RcppThread/Rcout.hpp"
+#include "RcppThread/Rcerr.hpp"
 #include "RcppThread/quickpool.hpp"
 
 #include <atomic>
@@ -232,10 +233,12 @@ ThreadPool::wait()
     do {
         pool_->wait(100);
         Rcout << "";
+        Rcerr << "";
         checkUserInterrupt();
 
     } while (!pool_->done());
     Rcout << "";
+    Rcerr << "";
 }
 
 //! waits for all jobs to finish.


### PR DESCRIPTION
This is a simple addition of safe printing to the R error stream (see #59). All test cases are passed. The PR does not include new test cases and documentation. The progress bar still uses `Rcout`.  Please let me know, if i can do anything to improve the PR.
