### PR TITLE
Enable check for standalone libatomic on Windows.

### DIFF
--- a/R/LdFlags.R
+++ b/R/LdFlags.R
@@ -25,9 +25,6 @@ writeLibAtomicTest <- function(file) {
 }
 
 checkForLibAtomic <- function() {
-    if (.Platform$OS.type == "windows")
-        return(TRUE)
-
     tmp <- createTestFiles()
     writeLibAtomicTest(tmp["src"])
     failed <- runCmd(getCompiler(), tmp["src"], "-o", tmp["out"], "-latomic")


### PR DESCRIPTION
This patch enables the check for standalone libatomic on Windows. While it is present in Rtools build of GCC, it is not with LLVM 17 (clang) for aarch64, so perhaps best not making an exception on Windows and checking as on the other platforms.

With the patch applied, the package builds and checks on my Windows/aarch64. Without the patch, it fails to build because of missing standalone libatomic.