### PR TITLE
-Fix R_NO_REMAP `warning: "R_NO_REMAP" redefined` compilation warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RcppThread
 Title: R-Friendly Threading in C++
-Version: 2.1.7
+Version: 2.1.8
 Authors@R: c(
     person("Thomas", "Nagler",, "mail@tnagler.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1855-0046"))

--- a/inst/include/RcppThread/RMonitor.hpp
+++ b/inst/include/RcppThread/RMonitor.hpp
@@ -7,7 +7,9 @@
 #pragma once
 
 // R API
+#ifndef R_NO_REMAP
 #define R_NO_REMAP
+#endif
 #include "Rinternals.h"
 #include "R.h"
 

--- a/src/detectCores.cpp
+++ b/src/detectCores.cpp
@@ -1,6 +1,8 @@
 #include <thread>
 
+#ifndef R_NO_REMAP
 #define R_NO_REMAP
+#endif
 
 #include <R.h>
 #include <Rdefines.h>


### PR DESCRIPTION
Compiling RcppExports.cpp when linking RcppThread can lead to a warning about redefining R_NO_REMAP: this PR adds a preprocessor guard to ensure it's only defined once.

See the following [build logs](https://productionresultssa0.blob.core.windows.net/actions-results/3d5e3d48-0bb8-4caf-aca8-909260ba4120/workflow-job-run-ee7c5540-d5c2-5dc1-5e58-077a799f02b7/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-12-29T17%3A52%3A35Z&sig=Wwa5q2NsaYX7Y7GqAIlTYzGlOqM9alNgmZ8mQN8DSq4%3D&ske=2024-12-30T03%3A09%3A59Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-12-29T15%3A09%3A59Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-11-04&sp=r&spr=https&sr=b&st=2024-12-29T17%3A42%3A30Z&sv=2024-11-04) (below is relevant excerpt):

```bash
2024-12-29T17:10:15.1806052Z g++  -std=gnu++20 -I"C:/R/include" -DNDEBUG  -I'D:/a/_temp/Library/Rcpp/include' -I'D:/a/_temp/Library/RcppThread/include' -I'D:/a/_temp/Library/progress/include' -I'D:/a/_temp/Library/spacefillr/include' -I'D:/a/_temp/Library/testthat/include'   -I"C:/rtools44/x86_64-w64-mingw32.static.posix/include"  -DRAY_REPRODUCE_PERLIN -DSTRICT_R_HEADERS -DRAY_WINDOWS -DHAS_SSE -DRAYSIMD -DRAYSIMDVECOFF -DR_NO_REMAP   -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign  -c RcppExports.cpp -o RcppExports.o
2024-12-29T17:10:15.2190025Z In file included from D:/a/_temp/Library/RcppThread/include/RcppThread.h:9,
2024-12-29T17:10:15.2190688Z                  from RcppExports.cpp:4:
2024-12-29T17:10:15.2191504Z D:/a/_temp/Library/RcppThread/include/RcppThread/RMonitor.hpp:10: warning: "R_NO_REMAP" redefined
2024-12-29T17:10:15.2192987Z    10 | #define R_NO_REMAP
2024-12-29T17:10:15.2193273Z       | 
2024-12-29T17:10:15.2193735Z <command-line>: note: this is the location of the previous definition
```